### PR TITLE
Add function to get all typeMembers including their type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,17 @@ const keysOfProps = keys<Props>();
 console.log(keysOfProps); // ['id', 'name', 'age']
 ```
 
-## How to use `classMembers`
+## How to use `typeMembers`
 
 ```ts
-import { classMembers } from 'ts-transformer-keys';
+import { typeMembers } from 'ts-transformer-keys';
 
 interface Props {
   id: string;
   name: string;
   age: number;
 }
-const membersOfProps = classMembers<Props>();
+const membersOfProps = typeMembers<Props>();
 
 console.log(keysOfProps); // {'id': 'string', 'name': 'string', 'age': 'number'}
 ```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ const keysOfProps = keys<Props>();
 console.log(keysOfProps); // ['id', 'name', 'age']
 ```
 
+## How to use `classMembers`
+
+```ts
+import { classMembers } from 'ts-transformer-keys';
+
+interface Props {
+  id: string;
+  name: string;
+  age: number;
+}
+const membersOfProps = classMembers<Props>();
+
+console.log(keysOfProps); // {'id': 'string', 'name': 'string', 'age': 'number'}
+```
+
 ## How to use the custom transformer
 
 Unfortunately, TypeScript itself does not currently provide any easy way to use custom transformers (See https://github.com/Microsoft/TypeScript/issues/14419).
@@ -168,8 +183,8 @@ console.log(keysOfProps); // ['id', 'name', 'age']
 
 # Note
 
-* The `keys` function can only be used as a call expression. Writing something like `keys.toString()` results in a runtime error.
-* `keys` does not work with a dynamic type parameter, i.e., `keys<T>()` in the following code is converted to an empty array(`[]`).
+* The functions can only be used as a call expression. Writing something like `keys.toString()` results in a runtime error.
+* The functions does not work with a dynamic type parameter, i.e., `keys<T>()` in the following code is converted to an empty array(`[]`).
 
 ```ts
 class MyClass<T extends object> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,3 @@
+interface IDictionary<T> {[key: string]: T;}
 export function keys<T extends object>(): Array<keyof T>;
-export function classMembers<T extends object>(): Array<keyof T>;
+export function classMembers<T extends object>(): IDictionary<string>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,2 @@
 export function keys<T extends object>(): Array<keyof T>;
+export function classMembers<T extends object>(): Array<keyof T>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,2 @@
-interface IDictionary<T> {[key: string]: T;}
 export function keys<T extends object>(): Array<keyof T>;
-export function classMembers<T extends object>(): IDictionary<string>;
+export function classMembers<T extends object>(): { [key in keyof T]: string; };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
 export function keys<T extends object>(): Array<keyof T>;
-export function classMembers<T extends object>(): { [key in keyof T]: string; };
+export function typeMembers<T extends object>(): { [key in keyof T]: string; };

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,27 +1,30 @@
-import { keys } from '../index';
+import {typeMembers, keys} from '../index';
 import assert from 'assert';
 import path from 'path';
 import fs from 'fs';
 import { compile } from './compile/compile';
 import ts from 'typescript';
 
+interface Foo {
+  foo: string;
+}
+
+type FooBar = {
+  foo: string;
+  bar?: number;
+};
+
+interface BarBaz {
+  bar: Function;
+  baz: Date;
+}
+
 describe('keys', () => {
   it('should return keys of given type', () => {
     assert.deepStrictEqual(keys(), []);
     assert.deepStrictEqual(keys<any>(), []);
-    interface Foo {
-      foo: string;
-    }
     assert.deepStrictEqual(keys<Foo>(), ['foo']);
-    type FooBar = {
-      foo: string;
-      bar?: number;
-    };
     assert.deepStrictEqual(keys<FooBar>(), ['foo', 'bar']);
-    interface BarBaz {
-      bar: Function;
-      baz: Date;
-    }
     assert.deepStrictEqual(keys<FooBar & BarBaz>(), ['foo', 'bar', 'baz']);
     assert.deepStrictEqual(keys<FooBar | BarBaz>(), ['bar']);
     assert.deepStrictEqual(keys<FooBar & any>(), []);
@@ -38,4 +41,17 @@ describe('keys', () => {
       }).timeout(0)
     )
   );
+});
+
+describe('typeMembers', () => {
+  it('should return type members of given type', () => {
+    assert.deepStrictEqual(typeMembers(), {});
+    assert.deepStrictEqual(typeMembers<any>(), {});
+    assert.deepStrictEqual(typeMembers<Foo>(), {foo: 'string'});
+    assert.deepStrictEqual(typeMembers<FooBar>(), {foo: 'string', bar: 'number | undefined'});
+    assert.deepStrictEqual(typeMembers<FooBar & BarBaz>(), {foo: 'string', bar: 'number & Function', baz: 'Date'});
+    assert.deepStrictEqual(typeMembers<FooBar | BarBaz>(), {bar: 'number | Function | undefined'});
+    assert.deepStrictEqual(typeMembers<FooBar & any>(), {});
+    assert.deepStrictEqual(typeMembers<FooBar | any>(), {});
+  });
 });

--- a/transformer.ts
+++ b/transformer.ts
@@ -26,17 +26,20 @@ function visitNode(node: ts.Node, program: ts.Program): ts.Node | undefined {
     const properties = typeChecker.getPropertiesOfType(type);
     return ts.createArrayLiteral(properties.map(property => ts.createLiteral(property.name)));
   }
-  else if (isCallExpression(node, typeChecker, 'classMembers')) {
+  else if (isCallExpression(node, typeChecker, 'typeMembers')) {
     if (!node.typeArguments) {
       return ts.createObjectLiteral([]);
     }
     const type = typeChecker.getTypeFromTypeNode(node.typeArguments[0]);
-    return ts.createObjectLiteral(typeChecker.getPropertiesOfType(type).map(property => {
-      return ts.createPropertyAssignment(
-        ts.createIdentifier(property.name),
-        ts.createStringLiteral(typeChecker.typeToString(typeChecker.getTypeOfSymbolAtLocation(property, property.valueDeclaration.parent)))
-      )
-    }));
+    const properties = typeChecker.getPropertiesOfType(type)
+      .filter(property => property.declarations && property.declarations.length > 0)
+      .map(property => {
+        return ts.createPropertyAssignment(
+          ts.createIdentifier(property.name),
+          ts.createStringLiteral(typeChecker.typeToString(typeChecker.getTypeOfSymbolAtLocation(property, property.declarations[0])))
+        )
+      });
+    return ts.createObjectLiteral(properties);
   } else {
     return node;
   }


### PR DESCRIPTION
I added another function to get all members of a given type including their type.

```
import { typeMembers } from 'ts-transformer-keys';

interface Props {
  id: string;
  name: string;
  age: number;
}
const membersOfProps = typeMembers<Props>();

console.log(keysOfProps); // {'id': 'string', 'name': 'string', 'age': 'number'}
```