### PR TITLE
Add "as const" to the End of Generated Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A TypeScript custom transformer which enables to obtain keys of given type.
 [![Downloads](https://img.shields.io/npm/dm/ts-transformer-keys.svg)](https://www.npmjs.com/package/ts-transformer-keys)
 
 # Requirement
-TypeScript >= 2.4.1
+TypeScript >= 3.4.1
 
 # How to use this package
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "typescript": "^4.9.3"
   },
   "peerDependencies": {
-    "typescript": ">=2.4.1"
+    "typescript": ">=3.4.1"
   }
 }

--- a/transformer.ts
+++ b/transformer.ts
@@ -3,6 +3,9 @@ import path from 'path';
 
 const createArrayExpression = ts.factory ? ts.factory.createArrayLiteralExpression : ts.createArrayLiteral;
 const createStringLiteral = ts.factory ? ts.factory.createStringLiteral : ts.createLiteral;
+const createAsExpression = ts.factory ? ts.factory.createAsExpression : ts.createAsExpression;
+const createIdentifier = ts.factory ? ts.factory.createIdentifier : ts.createIdentifier;
+const createTypeReferenceNode = ts.factory ? ts.factory.createTypeReferenceNode : ts.createTypeReferenceNode;
 
 export default function transformer(program: ts.Program): ts.TransformerFactory<ts.SourceFile> {
   return (context: ts.TransformationContext) => (file: ts.SourceFile) => visitNodeAndChildren(file, program, context);
@@ -29,7 +32,10 @@ function visitNode(node: ts.Node, program: ts.Program): ts.Node | undefined {
   }
   const type = typeChecker.getTypeFromTypeNode(node.typeArguments[0]);
   const properties = typeChecker.getPropertiesOfType(type);
-  return createArrayExpression(properties.map(property => createStringLiteral(property.name)));
+  const array = createArrayExpression(properties.map(property => createStringLiteral(property.name)));
+  return createAsExpression(array, createTypeReferenceNode(
+    createIdentifier("const")
+  ))
 }
 
 const indexJs = path.join(__dirname, 'index.js');


### PR DESCRIPTION
In [roblox-ts](https://roblox-ts.com/), type checking and transpiling of the TypeScript (into generated [Luau](https://luau-lang.org/)) is done *after* the transformers run. This leads to there being a type error of `Argument of type 'string' is not assignable to parameter of type 'YourTypeHere'.`. To fix this, an `as const` statment has been added to the end of the generated array. This does not seem to affect vanilla TS either as the tests pass.