### PR TITLE
Adds Typescript 5+ support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 !test/compile/index.js
 npm-debug.log*
 node_modules
+.vscode

--- a/examples/rollup/tsconfig.json
+++ b/examples/rollup/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "es2015",
     "moduleResolution": "node",
     "noEmitOnError": true,
-    "suppressImplicitAnyIndexErrors": true,
+    "noUncheckedIndexedAccess": false,
     "target": "ES5"
   },
   "exclude": [

--- a/examples/ts-jest/tsconfig.json
+++ b/examples/ts-jest/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "noEmitOnError": true,
-    "suppressImplicitAnyIndexErrors": true,
+    "noUncheckedIndexedAccess": false,
     "target": "ES5"
   },
   "files": [

--- a/examples/ttypescript/tsconfig.json
+++ b/examples/ttypescript/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "noEmitOnError": true,
-    "suppressImplicitAnyIndexErrors": true,
+    "noUncheckedIndexedAccess": false,
     "target": "ES5",
     "plugins": [
       { "transform": "ts-transformer-keys/transformer" }

--- a/examples/webpack/tsconfig.json
+++ b/examples/webpack/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "noEmitOnError": true,
-    "suppressImplicitAnyIndexErrors": true,
+    "noUncheckedIndexedAccess": false,
     "target": "ES5"
   },
   "exclude": [

--- a/test/compile/compile.ts
+++ b/test/compile/compile.ts
@@ -1,12 +1,26 @@
 import ts from 'typescript';
 import transformer from '../../transformer';
 
+function getDefaultModuleResolution(): ts.ModuleResolutionKind {
+  if('NodeJs' in ts.ModuleResolutionKind) {
+    return ts.ModuleResolutionKind.NodeJs;
+  }
+
+  if('Node10' in ts.ModuleResolutionKind) {
+    // @ts-ignore forward compatibility check
+    return ts.ModuleResolutionKind.Node10 as ts.ModuleResolutionKind;
+  }
+
+  throw new Error('Cannot choose default module resolution kind')
+}
+
 export function compile(filePaths: string[], target = ts.ScriptTarget.ES5, writeFileCallback?: ts.WriteFileCallback) {
   const program = ts.createProgram(filePaths, {
     strict: true,
     noEmitOnError: true,
-    suppressImplicitAnyIndexErrors: true,
+    noUncheckedIndexedAccess: false,
     esModuleInterop: true,
+    moduleResolution: getDefaultModuleResolution(),
     target
   });
   const transformers: ts.CustomTransformers = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "noEmitOnError": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "noUncheckedIndexedAccess": false
   },
   "include": [
     "transformer.ts",


### PR DESCRIPTION
Many deprecated parts of tsAPI were removed from the ts5 release, so updating to ts5 breaks projects.
Added support to the new API with the help of dynamic checks of what API version is used right now.